### PR TITLE
fix: downloader script fails on first run due to non-existing Plugins directory

### DIFF
--- a/DownloadPlugin.ps1
+++ b/DownloadPlugin.ps1
@@ -22,6 +22,10 @@ if ((Test-Path $pluginPathProject) -or (Test-Path $pluginPathEngine)) {
     exit 0
 }
 
+if (-not (Test-Path $projectPluginsDir)) {
+    $createPluginDirOutput = New-Item -Path $projectPluginsDir -ItemType "Directory"
+}
+
 Write-Host "Downloading plugin from $pluginURL..."
 $zipPath = "$projectPluginsDir\$pluginName.zip"
 Invoke-WebRequest -Uri $pluginURL -OutFile $zipPath

--- a/DownloadPlugin.sh
+++ b/DownloadPlugin.sh
@@ -21,6 +21,10 @@ if [ -d "$PLUGIN_PATH_PROJECT" ] || [ -d "$PLUGIN_PATH_ENGINE" ]; then
     exit 0
 fi
 
+if [ ! -d "$PROJECT_PLUGINS_DIR" ]; then
+    mkdir $PROJECT_PLUGINS_DIR
+fi
+
 echo "Downloading plugin from $PLUGIN_URL..."
 ZIP_PATH="$PROJECT_PLUGINS_DIR/$PLUGIN_NAME.zip"
 curl -L $PLUGIN_URL -o $ZIP_PATH


### PR DESCRIPTION
Downloader script failed because the Plugins directory doesn't exist after cloning, so downloading the plugin to that location failed:

```
PS C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest> .\DownloadPlugin.ps1
Downloading plugin from https://github.com/ArticySoftware/ArticyXImporterForUnreal/archive/refs/heads/master.zip...
Invoke-WebRequest : Could not find a part of the path 'C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest\Plugins\ArticyXImporter.zip'.
At C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest\DownloadPlugin.ps1:27 char:1
+ Invoke-WebRequest -Uri $pluginURL -OutFile $zipPath
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Invoke-WebRequest], DirectoryNotFoundException
    + FullyQualifiedErrorId : System.IO.DirectoryNotFoundException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

Extracting plugin...
Expand-Archive : The path 'C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest\Plugins\ArticyXImporter.zip' either does not exist or is not a valid file system path.
At C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest\DownloadPlugin.ps1:30 char:1
+ Expand-Archive -Path $zipPath -DestinationPath $projectPluginsDir -Fo ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (C:\Users\Tim\Do...cyXImporter.zip:String) [Expand-Archive], InvalidOperationException
    + FullyQualifiedErrorId : ArchiveCmdletPathNotFound,Expand-Archive

Renaming extracted folder...
Rename-Item : Cannot rename because item at 'C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest\Plugins\ArticyXImporterForUnreal-master' does not exist.
At C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest\DownloadPlugin.ps1:33 char:1
+ Rename-Item -Path "$projectPluginsDir\ArticyXImporterForUnreal-master ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Rename-Item], PSInvalidOperationException
    + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.RenameItemCommand

Cleaning up...
Remove-Item : Cannot find path 'C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest\Plugins\ArticyXImporter.zip' because it does not exist.
At C:\Users\Tim\Documents\Projects\ArticyUnreal\MMDemoTest\DownloadPlugin.ps1:36 char:1
+ Remove-Item -Path $zipPath -Force
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\Tim\Do...cyXImporter.zip:String) [Remove-Item], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand

Plugin installed successfully.
```

This PR ensures that the Plugins directory is created before download, if it doesn't exist yet.